### PR TITLE
Tries to cut down on as much copy paste as possible

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -609,7 +609,7 @@ Class Procs:
 /obj/machinery/proc/can_be_overridden()
 	. = 1
 
-/obj/machinery/tesla_act(power, tesla_flags, shocked_objects)
+/obj/machinery/tesla_act(power, tesla_flags, shocked_objects, zap_gib = FALSE)
 	..()
 	if((tesla_flags & TESLA_MACHINE_EXPLOSIVE) && !(resistance_flags & INDESTRUCTIBLE))
 		if(prob(60))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -240,11 +240,13 @@ GLOBAL_DATUM_INIT(acid_overlay, /mutable_appearance, mutable_appearance('icons/e
 		SSfire_burning.processing -= src
 
 ///Called when the obj is hit by a tesla bolt.
-/obj/proc/tesla_act(power, tesla_flags, shocked_targets)
+/obj/proc/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	obj_flags |= BEING_SHOCKED
 	addtimer(CALLBACK(src, PROC_REF(reset_shocked)), 10)
 	if(power < TESLA_MINI_POWER) //tesla bolts bounce twice, tesla miniball bolts bounce only once
 		return
+	var/power_bounced = power / 2
+	tesla_zap(src, 3, power_bounced, tesla_flags, shocked_targets, zap_gib)
 
 //The surgeon general warns that being buckled to certain objects receiving powerful shocks is greatly hazardous to your health
 ///Only tesla coils and grounding rods currently call this because mobs are already targeted over all other objects, but this might be useful for more things later.

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -209,7 +209,7 @@
 		if(prob(100 - severity * 30))
 			new /obj/effect/temp_visual/emp(get_turf(src))
 
-/obj/structure/blob/tesla_act(power)
+/obj/structure/blob/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	..()
 	if(overmind)
 		if(overmind.blobstrain.tesla_reaction(src, power))

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -428,7 +428,7 @@
 		return
 	qdel(src)
 
-/obj/machinery/nuclearbomb/tesla_act(power, tesla_flags)
+/obj/machinery/nuclearbomb/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	..()
 	if(tesla_flags & TESLA_MACHINE_EXPLOSIVE)
 		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -418,14 +418,14 @@
 			revive()
 			INVOKE_ASYNC(src, PROC_REF(emote), "gasp")
 			adjust_jitter(10 SECONDS)
-			adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199) //yogs end
-	if(gib && siemens_coeff>0)
+			adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199)
+	if(gib && siemens_coeff > 0)
 		visible_message(
-		span_danger("[src] body is emitting a loud noise!"), \
-		span_userdanger("You feel like you are about to explode!"), \
-		span_italics("You hear a loud noise!"), \
+			span_danger("[src] body is emitting a loud noise!"), \
+			span_userdanger("You feel like you are about to explode!"), \
+			span_italics("You hear a loud noise!"), \
 		)
-		addtimer(CALLBACK(src, PROC_REF(sm_gib)), 4 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(supermatter_tesla_gib)), 4 SECONDS) //yogs end
 	if(override)
 		return override
 	else

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -48,7 +48,7 @@
 				if(org_zone == BODY_ZONE_CHEST)
 					O.Remove(src)
 					O.forceMove(Tsec)
-					O.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+					O.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 	else
 		for(var/X in internal_organs)
 			var/obj/item/organ/I = X
@@ -60,34 +60,29 @@
 				continue
 			I.Remove(src)
 			I.forceMove(Tsec)
-			I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+			I.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 	if(!no_brain && !no_organs)//drop other heads/brains carried if your own would be dropped
 		for(var/X in src.get_all_contents())
 			if(istype(X, /obj/item/organ/brain) || istype(X, /obj/item/bodypart/head))
 				var/obj/item/H = X
 				if(H)
 					H.forceMove(Tsec)
-					H.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+					H.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 
 
 /mob/living/carbon/spread_bodyparts()
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
 		BP.drop_limb()
-		BP.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+		BP.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 
-/mob/living/carbon/proc/sm_gib() //leave chest behind and vital organs
-	for(var/obj/item/W in src)
-		dropItemToGround(W)
+/mob/living/carbon/proc/supermatter_tesla_gib() //leave chest behind and vital organs
+	for(var/obj/item/carbon_contents in src)
+		dropItemToGround(carbon_contents)
 		if(prob(50))
-			W.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
-	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)
+			carbon_contents.throw_at(get_edge_target_turf(src, pick(GLOB.alldirs)), rand(1,3), 5)
 	adjustFireLoss(1000)
-	spawn_gibs()
+	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	spill_organs()
-	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
-	if(B)
-		B.Remove(src)
-		B.forceMove(get_turf(src))
-		B.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 	spread_bodyparts()
+	spawn_gibs()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 	if(prob(20))
 		set_broken()
 
-/obj/machinery/gravity_generator/tesla_act(power, tesla_flags)
+/obj/machinery/gravity_generator/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	..()
 	if(tesla_flags & TESLA_MACHINE_EXPLOSIVE)
 		qdel(src)//like the singulo, tesla deletes it. stops it from exploding over and over

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -786,7 +786,7 @@
 	on = TRUE && !forced_off
 	update()
 
-/obj/machinery/light/tesla_act(power, tesla_flags)
+/obj/machinery/light/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	if(tesla_flags & TESLA_MACHINE_EXPLOSIVE)
 		explosion(src,0,0,0,flame_range = 5, adminlog = 0)
 		qdel(src)

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -96,6 +96,6 @@
 /obj/machinery/power/rtg/abductor/fire_act(exposed_temperature, exposed_volume)
 	overload()
 
-/obj/machinery/power/rtg/abductor/tesla_act()
+/obj/machinery/power/rtg/abductor/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	..() //extend the zap
 	overload()

--- a/code/modules/power/supermatter/supermatter_delamination.dm
+++ b/code/modules/power/supermatter/supermatter_delamination.dm
@@ -117,15 +117,15 @@
 
 /datum/supermatter_delamination/proc/call_tesla()
 	if(supermatter_turf)
-		var/obj/singularity/energy_ball/E = new(supermatter_turf)
-		E.energy = supermatter_power
-		message_admins("The Supermatter Crystal has created an energy ball [ADMIN_JMP(E)].")
+		var/obj/singularity/energy_ball/supermatter_tesla = new(supermatter_turf)
+		supermatter_tesla.energy = supermatter_power
+		message_admins("The Supermatter Crystal has created an energy ball [ADMIN_JMP(supermatter_tesla)].")
 
 /datum/supermatter_delamination/proc/call_cascadetesla()
 	if(supermatter_turf)
-		var/obj/singularity/energy_ball/supermatter/E = new(supermatter_turf)
-		E.energy += supermatter_power*100 // god
-		message_admins("The Supermatter Crystal has created an energy ball [ADMIN_JMP(E)].")
+		var/obj/singularity/energy_ball/supermatter/supermatter_tesla = new(supermatter_turf)
+		supermatter_tesla.energy += supermatter_power * 100 // god
+		message_admins("The Supermatter Crystal has created an energy ball [ADMIN_JMP(supermatter_tesla)].")
 
 /datum/supermatter_delamination/proc/call_blob()
 	var/list/candidates = pollGhostCandidates("Do you wish to be considered for the special role of Blazing Oil Blob?", ROLE_BLOB, null, ROLE_BLOB)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -78,7 +78,7 @@
 
 	return ..()
 
-/obj/machinery/power/tesla_coil/tesla_act(power, tesla_flags, shocked_targets)
+/obj/machinery/power/tesla_coil/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
 		add_avail((power * (1 - percentage_power_loss))*input_power_multiplier)
@@ -114,7 +114,7 @@
 	research_points_per_zap = 6 // level 1 coil: 44/m, level coil 2: 60/m, level coil 3: 90/m, level coil 4: 180/m
 	money_per_zap = 6
 
-/obj/machinery/power/tesla_coil/research/tesla_act(power, tesla_flags, shocked_things)
+/obj/machinery/power/tesla_coil/research/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
 		add_avail((power * (1 - percentage_power_loss))*input_power_multiplier)
@@ -178,7 +178,7 @@
 
 	return ..()
 
-/obj/machinery/power/grounding_rod/tesla_act(power)
+/obj/machinery/power/grounding_rod/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	if(anchored && !panel_open)
 		flick("grounding_rodhit", src)
 		tesla_buckle_check(power)

--- a/code/modules/power/tesla/generator.dm
+++ b/code/modules/power/tesla/generator.dm
@@ -5,6 +5,6 @@
 	icon_state = "TheSingGen"
 	creation_type = /obj/singularity/energy_ball
 
-/obj/machinery/the_singularitygen/tesla/tesla_act(power, tesla_flags)
+/obj/machinery/the_singularitygen/tesla/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	if(tesla_flags & TESLA_MACHINE_EXPLOSIVE)
 		energy += power

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -77,7 +77,7 @@
 /obj/structure/reagent_dispensers/fueltank/fire_act(exposed_temperature, exposed_volume)
 	boom()
 
-/obj/structure/reagent_dispensers/fueltank/tesla_act()
+/obj/structure/reagent_dispensers/fueltank/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	..() //extend the zap
 	boom()
 

--- a/code/modules/vehicles/bicycle.dm
+++ b/code/modules/vehicles/bicycle.dm
@@ -10,7 +10,7 @@
 	D.set_riding_offsets(RIDING_OFFSET_ALL, list(TEXT_NORTH = list(0, 4), TEXT_SOUTH = list(0, 4), TEXT_EAST = list(0, 4), TEXT_WEST = list( 0, 4)))
 	D.vehicle_move_delay = 0
 
-/obj/vehicle/ridden/bicycle/tesla_act() // :::^^^)))
+/obj/vehicle/ridden/bicycle/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE) // :::^^^)))
 	name = "fried bicycle"
 	desc = "Well spent."
 	color = rgb(63, 23, 4)

--- a/yogstation/code/game/gamemodes/gangs/dominator.dm
+++ b/yogstation/code/game/gamemodes/gangs/dominator.dm
@@ -51,7 +51,7 @@
 /obj/machinery/dominator/hulk_damage()
 	return (max_integrity - integrity_failure) / DOM_HULK_HITS_REQUIRED
 
-/obj/machinery/dominator/tesla_act()
+/obj/machinery/dominator/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
 	qdel(src)
 
 /obj/machinery/dominator/update_overlays()


### PR DESCRIPTION
# Document the changes in your pull request

Makes ``tesla_act`` work the same as it did previously, but it now has a gib arg so it can gib directly instead of having to call double.

Brings back the prob(80) check because I assume they have it there as a bandaid and I don't think we should kick that hornet's nest right now. Removes changing the color in process, moves it to when tesla balls start/stop orbiting a ball.